### PR TITLE
added some QoL vs code workspace settings.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,15 @@
+{
+    "terminal.integrated.profiles.osx": {
+        "rosdev": {
+            "path": "docker",
+            "args": [
+                "exec",
+                "-it",
+                "rosdev",
+                "bash"
+            ]
+        }
+    },
+    // optional: set the default profile to rosdev
+    // "terminal.integrated.defaultProfile.osx": "rosdev"
+}


### PR DESCRIPTION
This pull request includes a change to the `.vscode/settings.json` file to add a new terminal profile for macOS users. This profile allows users to execute commands inside a Docker container named `rosdev` using the integrated terminal in Visual Studio Code.

* [`.vscode/settings.json`](diffhunk://#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357R1-R15): Added a new terminal profile named `rosdev` for macOS users to execute commands inside a Docker container named `rosdev`.