### PR TITLE
Add Gazebo and speed improvement.

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update && apt-get install -y \
     ros-melodic-rviz \
     ros-melodic-turtlebot3 \
     ros-melodic-turtlebot3-msgs \
+    gazebo9 \
     xfce4 \
     xfce4-goodies \
     tigervnc-standalone-server\

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -19,7 +19,6 @@ RUN apt-get update && apt-get install -y \
     novnc \
     net-tools \
     supervisor \
-    dbus-x11 \
     websockify \
     # Add OpenGL and Qt dependencies
     libgl1-mesa-dri \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,11 +2,7 @@ FROM arm64v8/ros:melodic-ros-base-bionic
 
 ENV DEBIAN_FRONTEND=noninteractive \
     HOME=/root \
-    DISPLAY=:1 \
-    USER=root \
-    XDG_RUNTIME_DIR=/tmp/runtime-root \
-    QT_X11_NO_MITSHM=1 \
-    TURTLEBOT3_MODEL=burger
+    USER=root
 
 # Install VNC, XFCE4, and required packages
 RUN apt-get update && apt-get install -y \

--- a/.devcontainer/docker-compose.yaml
+++ b/.devcontainer/docker-compose.yaml
@@ -5,11 +5,9 @@ services:
       dockerfile: Dockerfile
     container_name: roscore
     command: roscore
-    networks:
-      - rosnet
+    network_mode: "host"
     environment:
-      - ROS_HOSTNAME=roscore
-      - ROS_MASTER_URI=http://roscore:11311
+      - ROS_MASTER_URI=http://localhost:11311
     restart: always
 
   rosdev:
@@ -17,18 +15,9 @@ services:
       context: .
       dockerfile: Dockerfile
     container_name: rosdev
-    ports:
-      - "5901:5901"
-      - "6080:6080"
-    networks:
-      - rosnet
+    network_mode: "host"
     environment:
-      - ROS_HOSTNAME=rosdev
-      - ROS_MASTER_URI=http://roscore:11311
+      - ROS_MASTER_URI=http://localhost:11311
     volumes:
       - ../catkin_ws:/root/catkin_ws
     restart: always
-
-networks:
-  rosnet:
-    driver: bridge

--- a/.devcontainer/docker-compose.yaml
+++ b/.devcontainer/docker-compose.yaml
@@ -18,6 +18,10 @@ services:
     network_mode: "host"
     environment:
       - ROS_MASTER_URI=http://localhost:11311
+      - DISPLAY=:1
+      - XDG_RUNTIME_DIR=/tmp/runtime-root
+      - TURTLEBOT3_MODEL=burger
+      - QT_X11_NO_MITSHM=1
     volumes:
       - ../catkin_ws:/root/catkin_ws
     restart: always


### PR DESCRIPTION
Got rid of using bridge mode so there should be little network overhead. This should speed up the visualization especially with running lots of data using `rosbag`. Also got rid of X11 specific installations and added gazebo.

Updates to environment configuration:

* [`.devcontainer/Dockerfile`](diffhunk://#diff-13bd9d7a30bf46656bc81f1ad5b908a627f9247be3f7d76df862b0578b534fc6L5-R5): Removed several environment variables (`DISPLAY=:1`, `XDG_RUNTIME_DIR=/tmp/runtime-root`, `QT_X11_NO_MITSHM=1`, `TURTLEBOT3_MODEL=burger`).

Package additions:

* [`.devcontainer/Dockerfile`](diffhunk://#diff-13bd9d7a30bf46656bc81f1ad5b908a627f9247be3f7d76df862b0578b534fc6R15-L25): Added `gazebo9` to the list of installed packages.

Network configuration changes:

* [`.devcontainer/docker-compose.yaml`](diffhunk://#diff-e96a798889398aad623ee0fa8ef4d316b5a72a5383f4534acbe805619458f263L8-L34): Changed `network_mode` to "host" and updated the `ROS_MASTER_URI` environment variable to use `localhost` for both `roscore` and `rosdev` services.